### PR TITLE
Logging working

### DIFF
--- a/generators/app/templates/src/StarterKit/Startup/LoggingEngineExtensions.cs
+++ b/generators/app/templates/src/StarterKit/Startup/LoggingEngineExtensions.cs
@@ -71,7 +71,7 @@ namespace StarterKit
       }
       if (env.Contains($"LOG_ELASTIC_APPLICATION_HEADERS"))
       {
-        environmentDict.Add("ApplicationLog:WriteTo:0:Args:connectionHeaders", env[$"LOG_ELASTIC_APPLICATION_HEADERS"].ToString());
+        environmentDict.Add("ApplicationLog:WriteTo:0:Args:connectionGlobalHeaders", env[$"LOG_ELASTIC_APPLICATION_HEADERS"].ToString());
       }
       if (env.Contains($"LOG_ELASTIC_APPLICATION_URL"))
       {
@@ -85,7 +85,7 @@ namespace StarterKit
       }
       if (env.Contains($"LOG_ELASTIC_SYSTEM_HEADERS"))
       {
-        environmentDict.Add("SystemLog:WriteTo:1:Args:connectionHeaders", env[$"LOG_ELASTIC_SYSTEM_HEADERS"].ToString());
+        environmentDict.Add("SystemLog:WriteTo:1:Args:connectionGlobalHeaders", env[$"LOG_ELASTIC_SYSTEM_HEADERS"].ToString());
       }
       if (env.Contains($"LOG_ELASTIC_SYSTEM_URL"))
       {


### PR DESCRIPTION
Changed the property name to set the authentication header for logging, when setting it from environment variables, from connectionHeaders to ConnectionGlobalHeaders.