### PR TITLE
Bugfix/api validator fixes

### DIFF
--- a/generators/app/templates/Dockerfile
+++ b/generators/app/templates/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1.301-focal AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
 WORKDIR /app
  
 # Copy csproj and restore as distinct layers
@@ -27,7 +27,7 @@ WORKDIR /app/src/StarterKit
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.5-focal AS runtime
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS runtime
 WORKDIR /app
 COPY --from=build-env /app/src/StarterKit/out .
 

--- a/generators/app/templates/src/StarterKit/Shared/Swagger/SetOperationDescription.cs
+++ b/generators/app/templates/src/StarterKit/Shared/Swagger/SetOperationDescription.cs
@@ -1,0 +1,14 @@
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace StarterKit.Shared.Swagger
+{
+  public class SetOperationDescription : IOperationFilter
+  {
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+      if (string.IsNullOrEmpty(operation.Description))
+        operation.Description = operation.Summary;
+    }
+  }
+}

--- a/generators/app/templates/src/StarterKit/Startup/Startup.cs
+++ b/generators/app/templates/src/StarterKit/Startup/Startup.cs
@@ -36,14 +36,6 @@ namespace StarterKit.Startup
     public IConfiguration Configuration { get; }
     public string ApplicationBasePath { get; }
     public IHostEnvironment Environment { get; }
-    private string XmlCommentsPath
-    {
-      get
-      {
-        var fileName = typeof(Startup).GetTypeInfo().Assembly.GetName().Name + ".xml";
-        return Path.Combine(ApplicationBasePath, fileName);
-      }
-    }
 
     public virtual void ConfigureServices(IServiceCollection services)
     {
@@ -156,11 +148,11 @@ namespace StarterKit.Startup
           options.OperationFilter<AddAuthorizationHeaderRequired>();
           options.OperationFilter<RemoveSyncRootParameter>();
           options.OperationFilter<LowerCaseQueryAndBodyParameterFilter>();
+          options.OperationFilter<SetOperationDescription>();
 
-          if (File.Exists(XmlCommentsPath))
-          {
-            options.IncludeXmlComments(XmlCommentsPath);
-          }
+          var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+          var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+          options.IncludeXmlComments(xmlPath);
         });
 
       #endregion
@@ -204,6 +196,7 @@ namespace StarterKit.Startup
 
       app.UseSwagger(options =>
       {
+        options.SerializeAsV2 = true;
         options.PreSerializeFilters.Add((swaggerDoc, httpReq) =>
         {
           swaggerDoc.Servers = new List<OpenApiServer>() { new OpenApiServer() { Url = $"{httpReq.Scheme}://{httpReq.Host.Value}" } };


### PR DESCRIPTION
Deze PR lost enkele validatiefouten voor de API validator op:
- XML remarks path
- Operation description
- Serialize as V2 (OpenApi 3.0 wordt momenteel nog niet ondersteund door de validator) 

Dockerfile aangepast naar net 5.0.