### PR TITLE
FIX: set scheme to HTTPS before first call is handled

### DIFF
--- a/generators/app/templates/src/StarterKit/Shared/Extensions/ApiExtensionsBuilder.cs
+++ b/generators/app/templates/src/StarterKit/Shared/Extensions/ApiExtensionsBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using Digipolis.Errors;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
@@ -36,6 +37,18 @@ namespace StarterKit.Shared.Extensions
 				RequireHeaderSymmetry = true,
 				ForwardedHeaders = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedHost |
 				                   Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto
+			});
+
+			app.Use(async (context, next) =>
+			{
+				// This line reads the X-Forwarded-Proto header sent by NgInx
+				// The first request is sent over HTTP/1 protocol and therefore it is needed to convert the scheme to HTTPS
+				var xForwardedProto = context.Request.Headers["X-Forwarded-Proto"].ToString();
+				if (xForwardedProto != null && xForwardedProto.StartsWith(Uri.UriSchemeHttps, StringComparison.InvariantCultureIgnoreCase))
+				{
+					context.Request.Scheme = Uri.UriSchemeHttps;
+				}
+				await next();
 			});
 		}
 	}


### PR DESCRIPTION
Huidige problematiek:

- Bij het openen van de Swagger pagina bij een gedeployede API is er enkel de mogelijkheid om het HTTP scheme te selecteren
- Hierdoor is de try out functionaliteit niet bruikbaar (HTTP <> HTTPS) aangezien de base url voor Swagger wordt opgebouwd met http prefix

- Oorzaak: eerste call die vanuit de reverse proxy gestuurd wordt is via HTTP voor het ophalen van de swagger.json. Hierdoor wordt het Scheme hier op HTTP gezet.

- Oplossing: Vanuit de Reverse proxy wordt een X-Forwarded-Proto header meegestuurd met hierin het correcte scheme. Deze moet meteen gezet worden 
